### PR TITLE
Fix bug causing navigation issue after second role signup

### DIFF
--- a/src/components/Onboarding/OnboardingRouter.js
+++ b/src/components/Onboarding/OnboardingRouter.js
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { roleMap } from "./helper";
 
 const OnboardingRouter = () => {
-  const { onboardingState, setOnboardingState, selectRole, setLoggedIn, isLoggedIn } =
+  const { onboardingState, setOnboardingState, selectRole, setLoggedIn, isLoggedIn, selectedRole } =
     useUser();
   const navigate = useNavigate();
 
@@ -33,6 +33,7 @@ const OnboardingRouter = () => {
         navigate(dashboardUrl);
       } else {
         console.error("Opening role is undefined. Handle this case appropriately.");
+        navigate(roleMap[selectedRole].dashboardUrl)
       }
     } else {
       const nextRole = roles.shift();


### PR DESCRIPTION
Previously, a bug occurred when one role had signed up while the other hadn't. If the app was refreshed during this process, after the second signup, the app failed to navigate to the signed-up role dashboard. This commit addresses this issue and ensures smooth navigation after both roles have been signed up.